### PR TITLE
Add an example for how to format a listing

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -39,6 +39,10 @@
 \usepackage[T1]{fontenc}
 \usepackage{microtype}
 
+\usepackage{minted}
+\usemintedstyle{colorful}
+\newminted[mlir]{tools/MLIRLexer.py:MLIRLexerOnlyOps -x}{mathescape}
+
 \usepackage{xargs}
 \usepackage{lipsum}
 \usepackage[textsize=tiny]{todonotes}
@@ -577,6 +581,27 @@ We also suggest to follow these technical remarks:
 }
 \label{fig:speedup}
 \end{figure}
+
+\subsubsection{Listings} We aim to use minted to create listings as much as
+possible, as this allows us to edit code quickly. We use syntax highlighting
+to make the parts of the code that matter most stand out. Hence, we keep
+most code black, comments gray, and highlight just the MLIR operands that
+we care about most.
+
+\begin{listing}
+% We cannot put '{' on a line after % in draftonly mode, as the hack we used to
+% not include the draft section will interpret the listing as normal
+% latex where '%' is a comment and {} need to match, which they will
+% not if only one is commented.
+\begin{mlir}
+// This is a comment
+def @foo(%0 : !dialect.type)
+{
+  %a = dialect.op(%0) : !dialect.type // $\color{black}\circled{1}$
+}
+\end{mlir}
+\caption{A simple MLIR code example}
+\end{listing}
 
 \end{draftonly}
 

--- a/tools/MLIRLexer.py
+++ b/tools/MLIRLexer.py
@@ -1,0 +1,43 @@
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import *
+
+class MLIRLexer(RegexLexer):
+    name = 'MLIR'
+    aliases = ['mlir']
+    filenames = ['*.mlir']
+
+    tokens = {
+        'root': [
+            (r'//.*?\n', Comment),
+            (r'%[^ ]*', Name.Variable),
+            (r'@[^(]*', Name.Function),
+            (r'\^[^(]*', Name.Label),
+            (r'(=)( +)([a-z]+)(\.)([a-z]+)', bygroups(Operator, Text, Name.Namespace, Text, Keyword.Function)),
+            (r'(!)([a-z]+)(\.)([a-z]+)', bygroups(Operator, Name.Namespace, Text, Keyword.Type)),
+            (r'(\n|\s)+', Text),
+            (r'[=<>{}:\[\]()*.,!]|x\b', Punctuation),
+            (r'def', Keyword),
+        ]
+    }
+
+# This Lexer is a hack that enables a custom style where only operation names
+# are highlighted and comments as well as dialect names are printed in light
+# gray.
+class MLIRLexerOnlyOps(RegexLexer):
+    name = 'MLIR'
+    aliases = ['mlir']
+    filenames = ['*.mlir']
+
+    tokens = {
+        'root': [
+            (r'//.*?\n', Comment),
+            (r'%[^ ]*', Text),
+            (r'@[^(]*', Text),
+            (r'\^[^(]*', Text),
+            (r'(=)( +)([a-z]+)(\.)([a-z]+)', bygroups(Text, Text, Comment, Comment, Name.Function)),
+            (r'(!)([a-z]+)(\.)([a-z]+)', bygroups(Text, Comment, Comment, Text)),
+            (r'(\n|\s)+', Text),
+            (r'[=<>{}:\[\]()*.,!]|x\b', Text),
+            (r'def', Text),
+        ]
+    }


### PR DESCRIPTION
This pull request adds a custom pygments formatter that allows us to syntax-highlight MLIR.

It currently supports:

- Lexing a simple subset of MLIR
- Highlighting only the OPs
- Adding \circled marks into the listing

[
![screenshot](https://user-images.githubusercontent.com/521960/127775624-b6adadaf-9235-4f26-b641-ae2f2b55acb1.png)
](url)