### PR TITLE
Non-draft mode: do not omit text that is referred to in a comment

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -72,8 +72,8 @@
 \else
 \newcommand\createtodoauthor[2]{%
 \def\tmpdefault{emptystring}%
-\expandafter\newcommand\csname #1\endcsname[2][\tmpdefault]{}%
-\expandafter\newcommand\csname #1f\endcsname[2][\tmpdefault]{}%
+\expandafter\newcommand\csname #1\endcsname[2][\tmpdefault]{##1}%
+\expandafter\newcommand\csname #1f\endcsname[2][\tmpdefault]{##1}%
 }%
 \fi
 


### PR DESCRIPTION
The underlined text seemed to disappear in non-draft mode previously.