### PR TITLE
non-draft mode: do not insert "emptystring" in place of comments

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -97,9 +97,8 @@
 %
 \else
 \newcommand\createtodoauthor[2]{%
-\def\tmpdefault{emptystring}%
-\expandafter\newcommand\csname #1\endcsname[2][\tmpdefault]{##1}%
-\expandafter\newcommand\csname #1f\endcsname[2][\tmpdefault]{##1}%
+\expandafter\newcommand\csname #1\endcsname[2][]{##1}%
+\expandafter\newcommand\csname #1f\endcsname[2][]{##1}%
 }%
 \fi
 


### PR DESCRIPTION
Not sure why this exists. It seemed to result in comments being replaced with the text `emptystring`. The paper seems to compile fine without it.