### PR TITLE
Fix include for bib file

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -574,7 +574,7 @@ the remaining paper should be to support the claims stated here.
 \fi
 
 %% Bibliography
-%\bibliography{bibfile}
+\bibliography{references}
 
 
 %% Appendix


### PR DESCRIPTION
- The bib file is called 'references' and non 'bibfile', thus rename to
'references'.

- For some reason the import of the bib file was commented.