### PR TITLE
[CI] Add write-all permissions.

### DIFF
--- a/.github/workflows/build_paper.yml
+++ b/.github/workflows/build_paper.yml
@@ -2,6 +2,10 @@
 
 name: Compile paper
 
+# Provide permissions to read and write the repo, create releases.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions: write-all
+
 # Controls when the action will run. Triggers the workflow on push or pull request 
 # events but only for the master branch
 on: [push, pull_request]


### PR DESCRIPTION
This allows CI to pass on forks of the repo, which it
was not before (eg. at `opencompl/paper-lean-mlir-semantics`),
where the action to create the github release was failing with a 403:

```
Run softprops/action-gh-release@v1
  with:
    name: Release 23
    tag_name: release-23
    files: paper.pdf
  draft.pdf

    token: ***
  env:
    GITHUB_TOKEN: ***
👩‍🏭 Creating new GitHub release for tag release-23...
⚠️ GitHub release failed with status: 403
undefined
```