### PR TITLE
Detect single-column pages automatically

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -120,7 +120,8 @@
 \patchcmd{\@addmarginpar}{\ifodd\c@page}{\ifodd\c@page\@tempcnta\m@ne}{}{}
 \makeatother
 \ifx\paperversion\paperversiondraft
-  \ifx\acmversion\acmversionjournal
+  \makeatletter
+  \if@ACM@journal
     \geometry{asymmetric}
     \paperwidth=\dimexpr \paperwidth + 3.5cm\relax
     \oddsidemargin=\dimexpr\oddsidemargin + 0cm\relax
@@ -189,6 +190,7 @@
     \marginparwidth=\dimexpr \marginparwidth + 3cm\relax
     \setlength{\marginparwidth}{4.6cm}
   \fi
+  \makeatother
 \fi
 
 % We use the following color scheme


### PR DESCRIPTION
If a paper is formatted in single-column layout, we want all comments to
be on one side, and only one margin to be extended. For some reason this
was removed in 2630238cf6060161d1fa1433a05ebcf4790f8c91.

@mathieu, do you know what you had in mind with your change?