### PR TITLE
FEAT: more functionality for highlighting MLIR/xDSL Code

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -79,6 +79,7 @@
 \usepackage{minted}
 \usemintedstyle{colorful}
 \newminted[mlir]{tools/MLIRLexer.py:MLIRLexerOnlyOps -x}{mathescape}
+\newminted[xdsl]{tools/MLIRLexer.py:MLIRLexer -x}{mathescape, style=murphy}
 
 \usepackage{xargs}
 \usepackage{lipsum}
@@ -741,7 +742,7 @@ to make the parts of the code that matter most stand out. Hence, we keep
 most code black, comments gray, and highlight just the MLIR operands that
 we care about most.
 
-\begin{listing}
+\begin{listing}[H]
 % We cannot put '{' on a line after % in draftonly mode, as the hack we used to
 % not include the draft section will interpret the listing as normal
 % latex where '%' is a comment and {} need to match, which they will
@@ -757,6 +758,37 @@ def @foo(%0 : !dialect.type)
 	captions and refer to labels, e.g. \circled[lst:example]{a}.}
 \label{lst:example}
 \end{listing}
+
+The syntax highlighting also works for xDSL-like IRs. Notice that different
+minted styles can be used for different environments. The xDSL environment uses
+the murphy-style in this case, whereas the MLIR version applies the
+colorful-style.
+
+\begin{xdsl}
+func.func() [sym_name = "main", function_type = !fun<[
+              !iterators.columnar_batch<!tuple<[!i64]>>
+                 ], []>] {
+  ^bb0(%0 : !iterators.columnar_batch<!tuple<[!i64]>>):
+    %t : !iterators.stream<!llvm.struct<[!i64]>> =
+      iterators.scan_columnar_batch(%0 : ...)
+    %filtered : !iterators.stream<!llvm.struct<[!i64]>> =
+          iterators.filter(%input : …) [predicateRef = @s0]
+    iterators.sink(%filtered : !iterators.stream<!tuple<[!i64]>>)
+    func.return()
+}
+
+func.func() [sym_name = "s0", function_type = !fun<[
+    !llvm.struct<[!i64]>], [!i1]>] {
+  ^bb0(%struct : !llvm.struct<[!i64]>):
+    %id : !i64 = llvm.extractvalue(%struct : ...)
+              [position = [0 : !index]]
+    %five  : !i64 = arith.constant() [value = 5 : !i64]
+    %cmp : !i1 = arith.cmpi(%id : !i64, %five : !i64)
+              [predicate = 4 : !i64]
+    func.return(%cmp : !i1)
+}
+\end{xdsl}
+
 
 \end{draftonly}
 

--- a/tools/MLIRLexer.py
+++ b/tools/MLIRLexer.py
@@ -13,13 +13,12 @@ non_assign_operation_rule = (r'([a-z_]+)(\.)([a-z_]+)',
 type_rule = (r'(!)([a-z_]+)(\.)([a-z0-9_]+)',
              bygroups(Operator, Name.Namespace, Text, Keyword.Type))
 abbrev_type_tule = (r'(!)([a-z0-9]+)', bygroups(Operator, Keyword.Type))
-first_attribute_rule = (r'([{\[])([a-z_]+)( = +)([a-z0-9">=]+)',
+first_attribute_rule = (r'([{\[])([a-z_A-Z]+)( = +)([@a-z0-9">=]+)',
                         bygroups(Text, Name.Attribute, Text, Name.Tag))
-following_attribute_rule = (r'(, +)([a-z_]+)( = +)([a-z0-9">=]+)',
+following_attribute_rule = (r'(, +)([a-z_]+)( = +)([a-z0-9">=@]+)',
                             bygroups(Text, Name.Attribute, Text, Name.Tag))
-abbrev_following_attribute_rule = (r'(, +)([a-z_]+)( = +)([a-z0-9">=]+)',
-                                   bygroups(Text, Name.Attribute, Text,
-                                            Name.Tag))
+abbrev_following_attribute_rule = (r'(, +)([a-z_]+)( = +)',
+                                   bygroups(Text, Name.Attribute, Text))
 
 
 class MLIRLexer(RegexLexer):

--- a/tools/MLIRLexer.py
+++ b/tools/MLIRLexer.py
@@ -1,6 +1,7 @@
 from pygments.lexer import RegexLexer, bygroups
 from pygments.token import *
 
+
 class MLIRLexer(RegexLexer):
     name = 'MLIR'
     aliases = ['mlir']
@@ -9,16 +10,29 @@ class MLIRLexer(RegexLexer):
     tokens = {
         'root': [
             (r'//.*?\n', Comment),
-            (r'%[^ ]*', Name.Variable),
+            (r'%[^[ )]*]*', Name.Variable),
             (r'@[^(]*', Name.Function),
-            (r'\^[^(]*', Name.Label),
-            (r'(=)( +)([a-z]+)(\.)([a-z]+)', bygroups(Operator, Text, Name.Namespace, Text, Keyword.Function)),
-            (r'(!)([a-z]+)(\.)([a-z]+)', bygroups(Operator, Name.Namespace, Text, Keyword.Type)),
+            (r'\^[^(:\]]*', Name.Label),
+            (r'(=)( +)([a-z_]+)(\.)([a-z_]+)',
+             bygroups(Operator, Text, Name.Namespace, Text, Keyword.Function)),
+            (r'([a-z_]+)(\.)([a-z_]+)',
+             bygroups(Name.Namespace, Text, Keyword.Function)),
+            (r'(!)([a-z_]+)(\.)([a-z0-9_]+)',
+             bygroups(Operator, Name.Namespace, Text, Keyword.Type)),
+            (r'(!)([a-z0-9]+)', bygroups(Operator, Keyword.Type)),
             (r'(\n|\s)+', Text),
+            (r'([{\[])([a-z_]+)( = +)([a-z0-9">=]+)',
+             bygroups(Text, Name.Attribute, Text, Name.Tag)),
+            (r'(\[)([a-z]+)', bygroups(Text, Name.Variable)),
+            (r'(, +)([a-z_]+)( = +)([a-z0-9">=]+)',
+             bygroups(Text, Name.Attribute, Text, Name.Tag)),
+            (r'(, +)([a-z_]+)( = +)', bygroups(Text, Name.Attribute, Text)),
             (r'[=<>{}:\[\]()*.,!]|x\b', Punctuation),
+            (r'(...)', Text),
             (r'def', Keyword),
         ]
     }
+
 
 # This Lexer is a hack that enables a custom style where only operation names
 # are highlighted and comments as well as dialect names are printed in light
@@ -34,8 +48,10 @@ class MLIRLexerOnlyOps(RegexLexer):
             (r'%[^ ]*', Text),
             (r'@[^(]*', Text),
             (r'\^[^(]*', Text),
-            (r'(=)( +)([a-z]+)(\.)([a-z]+)', bygroups(Text, Text, Comment, Comment, Name.Function)),
-            (r'(!)([a-z]+)(\.)([a-z]+)', bygroups(Text, Comment, Comment, Text)),
+            (r'(=)( +)([a-z]+)(\.)([a-z]+)',
+             bygroups(Text, Text, Comment, Comment, Name.Function)),
+            (r'(!)([a-z]+)(\.)([a-z]+)', bygroups(Text, Comment, Comment,
+                                                  Text)),
             (r'(\n|\s)+', Text),
             (r'[=<>{}:\[\]()*.,!]|x\b', Text),
             (r'def', Text),

--- a/tools/MLIRLexer.py
+++ b/tools/MLIRLexer.py
@@ -4,7 +4,7 @@ from pygments.token import Name, Keyword, Operator, Comment, Text, Punctuation, 
 comment_rule = (r'//.*?\n', Comment)
 ssa_value_rule = (r'%[^[ )]*]*', Name.Variable)
 symbol_rule = (r'@[^(]*', Name.Function)
-basic_block_rule = (r'@[^(]*', Name.Function)
+basic_block_rule = (r'\^[^(:\]]*', Name.Label)
 operation_rule = (r'(=)( +)([a-z_]+)(\.)([a-z_]+)',
                   bygroups(Operator, Text, Name.Namespace, Text,
                            Keyword.Function))

--- a/tools/MLIRLexer.py
+++ b/tools/MLIRLexer.py
@@ -1,5 +1,25 @@
 from pygments.lexer import RegexLexer, bygroups
-from pygments.token import *
+from pygments.token import Name, Keyword, Operator, Comment, Text, Punctuation, Literal
+
+comment_rule = (r'//.*?\n', Comment)
+ssa_value_rule = (r'%[^[ )]*]*', Name.Variable)
+symbol_rule = (r'@[^(]*', Name.Function)
+basic_block_rule = (r'@[^(]*', Name.Function)
+operation_rule = (r'(=)( +)([a-z_]+)(\.)([a-z_]+)',
+                  bygroups(Operator, Text, Name.Namespace, Text,
+                           Keyword.Function))
+non_assign_operation_rule = (r'([a-z_]+)(\.)([a-z_]+)',
+                             bygroups(Name.Namespace, Text, Keyword.Function))
+type_rule = (r'(!)([a-z_]+)(\.)([a-z0-9_]+)',
+             bygroups(Operator, Name.Namespace, Text, Keyword.Type))
+abbrev_type_tule = (r'(!)([a-z0-9]+)', bygroups(Operator, Keyword.Type))
+first_attribute_rule = (r'([{\[])([a-z_]+)( = +)([a-z0-9">=]+)',
+                        bygroups(Text, Name.Attribute, Text, Name.Tag))
+following_attribute_rule = (r'(, +)([a-z_]+)( = +)([a-z0-9">=]+)',
+                            bygroups(Text, Name.Attribute, Text, Name.Tag))
+abbrev_following_attribute_rule = (r'(, +)([a-z_]+)( = +)([a-z0-9">=]+)',
+                                   bygroups(Text, Name.Attribute, Text,
+                                            Name.Tag))
 
 
 class MLIRLexer(RegexLexer):
@@ -9,24 +29,19 @@ class MLIRLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'//.*?\n', Comment),
-            (r'%[^[ )]*]*', Name.Variable),
-            (r'@[^(]*', Name.Function),
-            (r'\^[^(:\]]*', Name.Label),
-            (r'(=)( +)([a-z_]+)(\.)([a-z_]+)',
-             bygroups(Operator, Text, Name.Namespace, Text, Keyword.Function)),
-            (r'([a-z_]+)(\.)([a-z_]+)',
-             bygroups(Name.Namespace, Text, Keyword.Function)),
-            (r'(!)([a-z_]+)(\.)([a-z0-9_]+)',
-             bygroups(Operator, Name.Namespace, Text, Keyword.Type)),
-            (r'(!)([a-z0-9]+)', bygroups(Operator, Keyword.Type)),
+            comment_rule,
+            ssa_value_rule,
+            symbol_rule,
+            basic_block_rule,
+            operation_rule,
+            non_assign_operation_rule,
+            type_rule,
+            abbrev_type_tule,
             (r'(\n|\s)+', Text),
-            (r'([{\[])([a-z_]+)( = +)([a-z0-9">=]+)',
-             bygroups(Text, Name.Attribute, Text, Name.Tag)),
+            first_attribute_rule,
             (r'(\[)([a-z]+)', bygroups(Text, Name.Variable)),
-            (r'(, +)([a-z_]+)( = +)([a-z0-9">=]+)',
-             bygroups(Text, Name.Attribute, Text, Name.Tag)),
-            (r'(, +)([a-z_]+)( = +)', bygroups(Text, Name.Attribute, Text)),
+            following_attribute_rule,
+            abbrev_following_attribute_rule,
             (r'[=<>{}:\[\]()*.,!]|x\b', Punctuation),
             (r'(...)', Text),
             (r'def', Keyword),


### PR DESCRIPTION
This PR adds support for syntax highlighting more IR styles, in particular xDSL style. As I did not follow MLIR's guidelines very closely but rather implemented syntax highlighting for the code i need in my thesis, this might support some ill-formatted IRs. However, I still wanted to make this available for more people.

I feel that we should probably refactor this majorly in order to make all the regex readable and understand what they are supposed to match on.