### PR TITLE
Support Listing in autoref

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -127,6 +127,8 @@
 \usetikzlibrary{shapes}
 \DeclareRobustCommand\circled[2][]{\ifthenelse{\isempty{#1}}{\tikz[baseline=(char.base)]{\node[shape=circle,fill=pairedOneLightBlue,inner sep=1pt] (char) {#2};}}{\autoref{#1}: \hyperref[#1]{\tikz[baseline=(char.base)]{\node[shape=circle,fill=pairedOneLightBlue,inner sep=1pt] (char) {#2};}}}}
 
+% listings don't write "Listing" in autoref without this.
+\providecommand*{\listingautorefname}{Listing}
 
 \begin{document}
 


### PR DESCRIPTION
Without this, \autoref{lst:affine} does not write Listing 1 for me. Instead it only writes 1. I don't know why it works in the Appendix though without this.