### PR TITLE
Add nixos support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  my-python = pkgs.python3;
+  python-with-my-packages = my-python.withPackages (p: with p; [
+    pygments
+  ]);
+in
+pkgs.mkShell {
+  name = "opencompl";
+  
+  packages = [
+    python-with-my-packages
+    pkgs.gnumake
+    # other dependencies
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -3,14 +3,48 @@ let
   my-python = pkgs.python3;
   python-with-my-packages = my-python.withPackages (p: with p; [
     pygments
+    # add more needed python packages here
   ]);
+
+  my-texlive = pkgs.texlive.combine { 
+    inherit (pkgs.texlive) 
+    scheme-medium
+
+    preprint
+    catchfile
+    comment
+    environ
+    framed
+    fvextra
+    hyperxmp
+    ifmtarg
+    lipsum
+    marginnote
+    minted
+    ncctools
+    pygmentex
+    todonotes
+    totpages
+    upquote
+    xargs
+    xifthen
+    xstring
+
+    # add more needed texlive packages here
+    ; 
+  };
 in
 pkgs.mkShell {
   name = "opencompl";
-  
+
   packages = [
     python-with-my-packages
+    # include this if you wish to run --pure shells, otherwise save you the trouble and use your texlive scheme-full system installation
+    # my-texlive
+
+    # "normal dependencies"
+    pkgs.python3
     pkgs.gnumake
-    # other dependencies
+    pkgs.which
   ];
 }


### PR DESCRIPTION
This PR aims to add native development and building support for NixOS.

It currently adds a `shell.nix` file containing all dependencies (except for texlive). 

If you wish to use pure nix-shells, you'll need to un-comment the `my-texlive` dependency, it should contain all required texlive packages. If you do this, you can successfully build drafts and papers using `nix-shell --pure --run "make all"`.