### PR TITLE
Make minted custom lexers work for old and new Texlive Releases

### DIFF
--- a/.github/workflows/build_paper_old.yml
+++ b/.github/workflows/build_paper_old.yml
@@ -16,37 +16,17 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    container:
+      # Most recent version of texlive image has broken minted/pygments
+      image: ghcr.io/xu-cheng/texlive-full:20221101
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
-
     - name: Compile draft
-      uses: xu-cheng/latex-action@master
-      with:
-        root_file: draft.tex
-
+      run: |
+        latexmk -shell-escape -pdf draft
     - name: Compile paper
-      uses: xu-cheng/latex-action@master
-      with:
-        root_file: paper.tex
-
-    - name: Format Python files with yapf
-      id: autoyapf
-      uses: mritunjaysharma394/autoyapf@v2
-      with:
-        args: --style pep8 --recursive --in-place .
-
-    - name: Release
-      if: ${{ github.event_name == 'push' }}
-      id: create_release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        name: Release ${{ github.run_number }}
-        tag_name: release-${{ github.run_number }}
-        files: |
-          paper.pdf
-          draft.pdf
+      run: |
+        latexmk -shell-escape -pdf paper

--- a/paper.tex
+++ b/paper.tex
@@ -50,11 +50,6 @@
 \usepackage[T1]{fontenc}
 \usepackage{microtype}
 
-\usepackage{minted}
-\usemintedstyle{colorful}
-\newminted[mlir]{tools/MLIRLexer.py:MLIRLexerOnlyOps -x}{mathescape}
-\newminted[xdsl]{tools/MLIRLexer.py:MLIRLexer -x}{mathescape, style=murphy}
-
 \usepackage{xargs}
 \usepackage{lipsum}
 \usepackage{xparse}
@@ -65,6 +60,22 @@
 
 \input{tex/setup.tex}
 \input{tex/acm.tex}
+
+\usemintedstyle{colorful}
+
+% Newer versions of minted require the 'customlexer' argument for custom lexers
+% whereas older versions require the '-x' to be passed via the command line.
+\makeatletter
+\ifcsdef{minted@optlistcl@quote}
+{
+\newminted[mlir]{tools/MLIRLexer.py:MLIRLexerOnlyOps}{customlexer, mathescape}
+\newminted[xdsl]{tools/MLIRLexer.py:MLIRLexer}{customlexer, mathescape, style=murphy}
+}
+{
+\newminted[mlir]{tools/MLIRLexer.py:MLIRLexerOnlyOps -x}{mathescape}
+\newminted[xdsl]{tools/MLIRLexer.py:MLIRLexer -x}{mathescape, style=murphy}
+}
+\makeatother
 
 % We use the following color scheme
 % 

--- a/tex/setup.tex
+++ b/tex/setup.tex
@@ -125,3 +125,49 @@
 \expandafter\newcommand\csname #1\endcsname[2][]{##1}%
 }%
 \fi
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Add minted and support costum lexers
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage{minted}
+\usepackage{etoolbox}
+
+\makeatletter
+\ifcsdef{minted@optlistcl@quote}
+{
+\ifwindows
+  \renewcommand{\minted@optlistcl@quote}[2]{%
+    \ifstrempty{#2}{\detokenize{#1}}{\detokenize{#1="#2"}}}
+\else
+  \renewcommand{\minted@optlistcl@quote}[2]{%
+    \ifstrempty{#2}{\detokenize{#1}}{\detokenize{#1='#2'}}}
+\fi
+
+% similar to \minted@def@optcl@switch
+\newcommand{\minted@def@optcl@novalue}[2]{%
+  \define@booleankey{minted@opt@g}{#1}%
+    {\minted@addto@optlistcl{\minted@optlistcl@g}{#2}{}%
+     \@namedef{minted@opt@g:#1}{true}}
+    {\@namedef{minted@opt@g:#1}{false}}
+  \define@booleankey{minted@opt@g@i}{#1}%
+    {\minted@addto@optlistcl{\minted@optlistcl@g@i}{#2}{}%
+     \@namedef{minted@opt@g@i:#1}{true}}
+    {\@namedef{minted@opt@g@i:#1}{false}}
+  \define@booleankey{minted@opt@lang}{#1}%
+    {\minted@addto@optlistcl@lang{minted@optlistcl@lang\minted@lang}{#2}{}%
+     \@namedef{minted@opt@lang\minted@lang:#1}{true}}
+    {\@namedef{minted@opt@lang\minted@lang:#1}{false}}
+  \define@booleankey{minted@opt@lang@i}{#1}%
+    {\minted@addto@optlistcl@lang{minted@optlistcl@lang\minted@lang @i}{#2}{}%
+     \@namedef{minted@opt@lang\minted@lang @i:#1}{true}}
+    {\@namedef{minted@opt@lang\minted@lang @i:#1}{false}}
+  \define@booleankey{minted@opt@cmd}{#1}%
+      {\minted@addto@optlistcl{\minted@optlistcl@cmd}{#2}{}%
+        \@namedef{minted@opt@cmd:#1}{true}}
+      {\@namedef{minted@opt@cmd:#1}{false}}
+}
+\minted@def@optcl@novalue{customlexer}{-x}
+}
+{
+}
+\makeatother

--- a/tools/create-video.py
+++ b/tools/create-video.py
@@ -201,7 +201,9 @@ def createImage(data):
 
     shutil.copyfile("Makefile", dirname + "/Makefile")
     shutil.copyfile(".latexmkrc", dirname + "/.latexmkrc")
-    run(['make', '-C', dirname, f"{base_filename}.pdf"], stdout=DEVNULL, stderr=STDOUT)
+    cmd = ['make', '-C', dirname, f"{base_filename}.pdf"]
+    print(" ".join(cmd))
+    #run(['make', '-C', dirname, f"{base_filename}.pdf"], stdout=STDOUT, stderr=STDOUT)
     createImageOfPaper(dirname + f"/{base_filename}.pdf")
     plotStatistics(commit,  dirname + "/statistics.png", branch, count)
     run(['convert', dirname + f"/{base_filename}.pdf-full.png", '-resize', '3840x2160',


### PR DESCRIPTION
The minted 2.7 release changed its behaviour to not allow for custom command line options, which broke our custom lexer definitions. Here is a similar bug reported: https://github.com/gpoore/minted/issues/360.
    
This commit adds a new minted option that allows custom lexers to work with newer texlive distributions. We also enhance our CI to check that the paper builds with old and new textlive distributions.
