### PR TITLE
Fix circled command

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -149,17 +149,26 @@
 
 % Define base style for circled nodes
 \tikzset{
-  circledbase/.style={
+  circledstyle/.style={
     shape=circle,
-    fill=pairedOneLightBlue,
+    #1,
     font=\tt\small,
-        inner sep=0pt,
-        outer sep=0pt,
-        minimum size=1.2em
-    }
+    inner sep=0pt,
+    outer sep=0pt,
+    minimum size=1.2em,
+    text=black
+  }
 }
 
-\DeclareRobustCommand\circled[2][]{\ifthenelse{\isempty{#1}}{\tikz[baseline=(char.base)]{\node[circledbase] (char) {#2\strut};}}{\autoref{#1}: \hyperref[#1]{\tikz[baseline=(char.base)]{\node[circledbase] (char) {#2\strut};}}}}
+\DeclareRobustCommand{\circledbase}[2][]{%
+  \tikz[baseline=(char.base)]{\node[circledstyle, #1] (char) {#2\strut};}%
+}
+
+\DeclareRobustCommand{\circled}[2][]{%
+    \ifthenelse{\isempty{#1}}%
+        {\circledbase[fill=pairedOneLightBlue]{#2}}%
+        {\autoref{#1}: \hyperref[#1]{\circledbase[fill=pairedOneLightBlue]{#2}}}%
+}
 
 % listings don't write "Listing" in autoref without this.
 \providecommand*{\listingautorefname}{Listing}

--- a/paper.tex
+++ b/paper.tex
@@ -139,31 +139,9 @@
 \newunicodechar{α}{\ensuremath{\alpha}}
 \newunicodechar{β}{\ensuremath{\beta}}
 
-
 % \circled command to print a colored circle.
 % \circled{1} pretty-prints "(1)"
 % This is useful to refer to labels that are embedded within figures.
-\usepackage{tikz}
-\usetikzlibrary{arrows}
-\usetikzlibrary{shapes}
-
-% Define base style for circled nodes
-\tikzset{
-  circledstyle/.style={
-    shape=circle,
-    #1,
-    font=\tt\small,
-    inner sep=0pt,
-    outer sep=0pt,
-    minimum size=1.2em,
-    text=black
-  }
-}
-
-\DeclareRobustCommand{\circledbase}[3][]{%
-    \tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}%
-}
-
 \DeclareRobustCommand{\circled}[2][]{%
     \ifthenelse{\isempty{#1}}%
         {\circledbase{pairedOneLightBlue}{#2}}%

--- a/paper.tex
+++ b/paper.tex
@@ -160,14 +160,16 @@
   }
 }
 
-\DeclareRobustCommand{\circledbase}[2][]{%
-  \tikz[baseline=(char.base)]{\node[circledstyle, #1] (char) {#2\strut};}%
+\DeclareRobustCommand{\circledbase}[3][]{%
+    \ifthenelse{\isempty{#1}}%
+        {\tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}}%
+        {\tikz[baseline=(char.base)]{\node[circledstyle, fill=#2, #1] (char) {#3\strut};}}%
 }
 
 \DeclareRobustCommand{\circled}[2][]{%
     \ifthenelse{\isempty{#1}}%
-        {\circledbase[fill=pairedOneLightBlue]{#2}}%
-        {\autoref{#1}: \hyperref[#1]{\circledbase[fill=pairedOneLightBlue]{#2}}}%
+        {\circledbase{pairedOneLightBlue}{#2}}%
+        {\autoref{#1}: \hyperref[#1]{\circledbase{pairedOneLightBlue}{#2}}}%
 }
 
 % listings don't write "Listing" in autoref without this.

--- a/paper.tex
+++ b/paper.tex
@@ -146,7 +146,20 @@
 \usepackage{tikz}
 \usetikzlibrary{arrows}
 \usetikzlibrary{shapes}
-\DeclareRobustCommand\circled[2][]{\ifthenelse{\isempty{#1}}{\tikz[baseline=(char.base)]{\node[shape=circle,fill=pairedOneLightBlue,inner sep=1pt] (char) {#2};}}{\autoref{#1}: \hyperref[#1]{\tikz[baseline=(char.base)]{\node[shape=circle,fill=pairedOneLightBlue,inner sep=1pt] (char) {#2};}}}}
+
+% Define base style for circled nodes
+\tikzset{
+  circledbase/.style={
+    shape=circle,
+    fill=pairedOneLightBlue,
+    font=\tt\small,
+        inner sep=0pt,
+        outer sep=0pt,
+        minimum size=1.2em
+    }
+}
+
+\DeclareRobustCommand\circled[2][]{\ifthenelse{\isempty{#1}}{\tikz[baseline=(char.base)]{\node[circledbase] (char) {#2\strut};}}{\autoref{#1}: \hyperref[#1]{\tikz[baseline=(char.base)]{\node[circledbase] (char) {#2\strut};}}}}
 
 % listings don't write "Listing" in autoref without this.
 \providecommand*{\listingautorefname}{Listing}

--- a/paper.tex
+++ b/paper.tex
@@ -161,9 +161,7 @@
 }
 
 \DeclareRobustCommand{\circledbase}[3][]{%
-    \ifthenelse{\isempty{#1}}%
-        {\tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}}%
-        {\tikz[baseline=(char.base)]{\node[circledstyle, fill=#2, #1] (char) {#3\strut};}}%
+    \tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}%
 }
 
 \DeclareRobustCommand{\circled}[2][]{%

--- a/tex/setup.tex
+++ b/tex/setup.tex
@@ -200,7 +200,6 @@
 }
 
 % define a base tikz node for circled commands accepting a fill colour and the node text as arguments
-% 
 \DeclareRobustCommand{\circledbase}[3][]{%
     \tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}%
 }

--- a/tex/setup.tex
+++ b/tex/setup.tex
@@ -127,7 +127,7 @@
 \fi
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Add minted and support costum lexers
+% Add minted and support custom lexers
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage{minted}
 \usepackage{etoolbox}

--- a/tex/setup.tex
+++ b/tex/setup.tex
@@ -171,3 +171,26 @@
 {
 }
 \makeatother
+
+% base style and command for \circled to print a colored circle.
+\usepackage{tikz}
+\usetikzlibrary{arrows}
+\usetikzlibrary{shapes}
+
+% Define base style for circled nodes
+\tikzset{
+  circledstyle/.style={
+    shape=circle,
+    #1,
+    font=\tt\small,
+    inner sep=0pt,
+    outer sep=0pt,
+    minimum size=1.2em,
+    text=black
+  }
+}
+
+\DeclareRobustCommand{\circledbase}[3][]{%
+    \tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}%
+}
+

--- a/tex/setup.tex
+++ b/tex/setup.tex
@@ -172,12 +172,21 @@
 }
 \makeatother
 
-% base style and command for \circled to print a colored circle.
 \usepackage{tikz}
 \usetikzlibrary{arrows}
 \usetikzlibrary{shapes}
 
-% Define base style for circled nodes
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Base style and command for \circled to print a colored circle
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Width is assured to be the same across all characters using the typewriter font which is monospaced
+% Zeroing out the inner separator removes padding between content and node (inner sep).
+% Zeroing out the outer separator removes space between the node border and its anchors (e.g., east).
+% Minimum size was derived on experimentation and it may need adjustment when changing font style/size.
+%
+% There is no guarantee for the letter ascenders/descenders to baseline when set to char.base, hence adding \strut.
+% which is an invisible vertical rule with the height and depth of the parentheses ( and ).
+% It ensures that the line height in a line of text is at least as large as if it contained parentheses. 
 \tikzset{
   circledstyle/.style={
     shape=circle,
@@ -190,6 +199,8 @@
   }
 }
 
+% define a base tikz node for circled commands accepting a fill colour and the node text as arguments
+% 
 \DeclareRobustCommand{\circledbase}[3][]{%
     \tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}%
 }


### PR DESCRIPTION
This PR:

- Factors out the tikz node style to avoid repetition
- Fixes #41 (there is no typographic guarantee regarding the total height of letters wrt cap height and/or ascenders in a character, so the numbers are a result of experimenting with what accommodates letters with ascenders and descenders)

A lot of this is based on the `\strut` suggestion [here][1].

![2024-03-21-134833_1324x203_scrot](https://github.com/opencompl/paper-template/assets/3405733/24c0168a-334c-4bb1-be4f-a28ecece650c)

[1]: https://tex.stackexchange.com/a/199056/78375