### PR TITLE
Print comments in paper.pdf and create submission.pdf without comments

### DIFF
--- a/.github/workflows/build_paper.yml
+++ b/.github/workflows/build_paper.yml
@@ -22,15 +22,15 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
 
-    - name: Compile draft
-      uses: xu-cheng/latex-action@master
-      with:
-        root_file: draft.tex
-
     - name: Compile paper
       uses: xu-cheng/latex-action@master
       with:
         root_file: paper.tex
+
+    - name: Compile submission
+      uses: xu-cheng/latex-action@master
+      with:
+        root_file: submission.tex
 
     - name: Format Python files with yapf
       id: autoyapf
@@ -49,4 +49,4 @@ jobs:
         tag_name: release-${{ github.run_number }}
         files: |
           paper.pdf
-          draft.pdf
+          submission.pdf

--- a/.github/workflows/build_paper_old.yml
+++ b/.github/workflows/build_paper_old.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
-    - name: Compile draft
-      run: |
-        latexmk -shell-escape -pdf draft
     - name: Compile paper
       run: |
         latexmk -shell-escape -pdf paper
+    - name: Compile submission
+      run: |
+        latexmk -shell-escape -pdf submission

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,10 @@
 # Source Latex files
-TEX_MAIN = paper.tex
-
-TEX_MAIN_DRAFT = draft.tex
 TEX_MAIN_PAPER = paper.tex
-TEX_MAIN_BLIND = blind.tex
-TEX_MAIN_CAMERA_ACM = cameraACM.tex
+TEX_MAIN_SUBMISSION = submission.tex
 
 # Generate PDF files
-PDF_DRAFT = draft.pdf
 PDF_PAPER = paper.pdf
-PDF_BLIND = blind.pdf
-PDF_CAMERA_ACM = cameraACM.pdf
+PDF_SUBMISSION = submission.pdf
 
 IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
 
@@ -18,7 +12,7 @@ IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
 # from textidote
 .PHONY: grammar
 
-all: ${PDF_DRAFT} ${PDF_PAPER}
+all: ${PDF_SUBMISSION} ${PDF_PAPER}
 
 # spelling and grammar
 grammar: paper.tex
@@ -28,32 +22,21 @@ grammar: paper.tex
 	-textidote --check en --output html paper.tex > index.html
 	python3 -m http.server
 
-
-${PDF_DRAFT}: ${TEX_MAIN_DRAFT} ${TEX_MAIN} ${IMAGES}
-	latexmk ${TEX_MAIN_DRAFT}
-
-${PDF_PAPER}: ${TEX_MAIN_PAPER} ${TEX_MAIN} ${IMAGES}
+${PDF_PAPER}: ${TEX_MAIN_PAPER} ${IMAGES}
 	latexmk ${TEX_MAIN_PAPER}
 
-${PDF_CAMERA_ACM}: ${TEX_MAIN_CAMERA_ACM} ${TEX_MAIN} ${IMAGES}
-	latexmk ${TEX_MAIN_CAMERA_ACM}
-
-draft: ${PDF_DRAFT}
-
-blind: ${PDF_BLIND}
+${PDF_SUBMISSION}: ${TEX_MAIN_SUBMISSION} ${IMAGES}
+	latexmk ${TEX_MAIN_SUBMISSION}
 
 paper: ${PDF_PAPER}
 
-cameraACM: ${PDF_CAMERA_ACM}
+submission: ${PDF_SUBMISSION}
 
-view-draft: ${TEX_MAIN_DRAFT} ${TEX_MAIN} ${IMAGES}
-	latexmk -pvc ${TEX_MAIN_DRAFT}
-
-view-paper: ${TEX_MAIN_PAPER} ${TEX_MAIN} ${IMAGES}
+view-paper: ${TEX_MAIN_PAPER} ${IMAGES}
 	latexmk -pvc ${TEX_MAIN_PAPER}
 
-view-camera-acm: ${TEX_MAIN_CAMERA_ACM} ${TEX_MAIN} ${IMAGES}
-	latexmk -pvc ${TEX_MAIN_CAMERA_ACM}
+view-submission: ${TEX_MAIN_SUBMISSION} ${IMAGES}
+	latexmk -pvc ${TEX_MAIN_SUBMISSION}
 
 clean:
 	latexmk -C

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Compile paper](../../workflows/Compile%20paper/badge.svg)
 
 Download:
-[Draft (with comments)](../../releases/latest/download/draft.pdf) |
-[Paper](../../releases/latest/download/paper.pdf)
+[Paper (with comments)](../../releases/latest/download/paper.pdf)
+[Submission (without comments)](../../releases/latest/download/submission.pdf) |
 
 This repository serves as a template for writing computer science papers in LaTeX. It supports
 the following features:

--- a/draft.tex
+++ b/draft.tex
@@ -1,2 +1,0 @@
-\def\paperversion{draft}
-\input{paper}

--- a/paper.tex
+++ b/paper.tex
@@ -1,21 +1,14 @@
 \def\paperversiondraft{draft}
-\def\paperversionblind{normal}
-\def\paperversioncameraACM{cameraACM}
+\def\paperversionnormal{normal}
 
-% If no draft paper-version is requested, compile in 'normal' mode
-\ifx\paperversion\paperversiondraft
+% If the paper version is set to 'normal' mode keep it,
+% otherwise set it to 'draft' mode.
+\ifx\paperversion\paperversionnormal
 \else
-  \ifx\paperversion\paperversioncameraACM
-  \else
-  \def\paperversion{normal}
-  \fi
+  \def\paperversion{draft}
 \fi
 
-\ifx\paperversion\paperversioncameraACM
-  \documentclass[sigplan]{acmart}
-\else
-  \documentclass[review, anonymous, sigplan]{acmart}
-\fi
+\documentclass[review, anonymous, sigplan]{acmart}
 
 \def\acmversionanonymous{anonymous}
 \def\acmversionjournal{journal}

--- a/submission.tex
+++ b/submission.tex
@@ -1,0 +1,2 @@
+\def\paperversion{normal}
+\input{paper}


### PR DESCRIPTION
When editing a paper we want to see the version with comments. In VSCode, it is easy to look at the PDF that is created from the main .tex file, paper.tex in our case. Hence, we make this version the one with comments.

For submission, we always have submission.pdf that will give us a file without comments and without extended document size.