### PR TITLE
Add minor `Makefile` improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-# Source Latex files
+# Source LaTex files
 TEX_MAIN_PAPER = paper.tex
 TEX_MAIN_SUBMISSION = submission.tex
 
-# Generate PDF files
+# Generated PDF files
 PDF_PAPER = paper.pdf
 PDF_SUBMISSION = submission.pdf
 
+# Resources
 IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
 
 # grammar is a phony rule, it generates index.html

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,7 @@ PDF_SUBMISSION = submission.pdf
 # Resources
 IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
 
-# grammar is a phony rule, it generates index.html
-# from textidote
-.PHONY: grammar
+.PHONY: all grammar paper submission view-paper view-submission clean
 
 all: ${PDF_SUBMISSION} ${PDF_PAPER}
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Source LaTex files
+# Source LaTeX files
 TEX_MAIN_PAPER = paper.tex
 TEX_MAIN_SUBMISSION = submission.tex
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ TEX_MAIN_PAPER = paper.tex
 TEX_MAIN_SUBMISSION = submission.tex
 
 # Generated PDF files
-PDF_PAPER = paper.pdf
-PDF_SUBMISSION = submission.pdf
+PDF_PAPER := $(TEX_MAIN_PAPER:.tex=.pdf)
+PDF_SUBMISSION := $(TEX_MAIN_SUBMISSION:.tex=.pdf)
 
 # Resources
 IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
@@ -14,11 +14,11 @@ IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
 all: ${PDF_SUBMISSION} ${PDF_PAPER}
 
 # spelling and grammar
-grammar: paper.tex
+grammar: $(TEX_MAIN_PAPER)
 	# check that textidote exists.
 	@textidote --version
 	# allowed to fail since it throws error if we have grammar mistakes
-	-textidote --check en --output html paper.tex > index.html
+	-textidote --check en --output html $< > index.html
 	python3 -m http.server
 
 ${PDF_PAPER}: ${TEX_MAIN_PAPER} ${IMAGES}


### PR DESCRIPTION
This PR adds minor improvements (mostly DRY-specific) to the `Makefile`:

- Define the TeX filenames once and use their variables everywhere else needed
- Declare all phony targets