### PR TITLE
Add hyphenation package and explanation

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -55,6 +55,7 @@
 \usepackage{thmtools} % required for autoref to lemmas
 \usepackage{algorithm}
 \usepackage[noend]{algpseudocode}
+\usepackage{hyphenat}
 
 \input{tex/setup.tex}
 \input{tex/acm.tex}
@@ -662,6 +663,10 @@ For example, assume we have defined an acronym with \texttt{\textbackslash{}newa
   \item To force contraction (e.g., to save space for a figure caption), we use \texttt{\textbackslash{}acs\{ir\}} which gives: \acs{ir}.
   \item To obtain plural form, we use \texttt{\textbackslash{}acp\{ir\}} giving: \acp{ir}.
 \end{itemize}
+
+\subsubsection{Adding hyphenation rules}
+While \LaTeX\ handles word breaks automatically, and packages like \texttt{microtype} aim to minimize word splitting, there are instances where either new words lack hyphenation rules, or the suggested hyphenation for a word is undesirable.
+The \texttt{hyphenat} package allows adding hyphenation rules using the \texttt{\textbackslash{}hyphenation} macro, e.g., \texttt{\textbackslash{}hyphenation\{Alex-Net\}} for AlexNet.
 
 \end{draftonly}
 

--- a/paper.tex
+++ b/paper.tex
@@ -56,6 +56,7 @@
 \usepackage{algorithm}
 \usepackage[noend]{algpseudocode}
 \usepackage{hyphenat}
+\usepackage[shortcuts]{extdash}
 
 \input{tex/setup.tex}
 \input{tex/acm.tex}
@@ -667,6 +668,9 @@ For example, assume we have defined an acronym with \texttt{\textbackslash{}newa
 \subsubsection{Adding hyphenation rules}
 While \LaTeX\ handles word breaks automatically, and packages like \texttt{microtype} aim to minimize word splitting, there are instances where either new words lack hyphenation rules, or the suggested hyphenation for a word is undesirable.
 The \texttt{hyphenat} package allows adding hyphenation rules using the \texttt{\textbackslash{}hyphenation} macro, e.g., \texttt{\textbackslash{}hyphenation\{Alex-Net\}} for AlexNet.
+
+Allowing hyphenation of compound words, we can use \texttt{\textbackslash{}-/} from the \texttt{extdash} package, for example \texttt{high\-/level} can be written as \texttt{high\textbackslash{}-/level}.
+Disallowing a line break at the compound word hyphen, we can use \texttt{\textbackslash{}=/}, as \texttt{RISC\textbackslash{}=/V} for \texttt{RISC\=/V}.
 
 \end{draftonly}
 


### PR DESCRIPTION
This PR:

- Adds `hyphenat` package
- Gives example of how to customize hyphenation in the writing guidelines, as it is too common to have CS names that have no hyphenation rules in the default LaTeX Texlive distro.