### PR TITLE
Adds `Makefile` check for all labelled elements are not referenced in text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ IMAGES := $(wildcard images/*.jpg images/*.pdf images/*.png)
 all: ${PDF_SUBMISSION} ${PDF_PAPER}
 
 # spelling and grammar
-grammar: paper.tex
+grammar: $(TEX_MAIN_PAPER)
 	# check that textidote exists.
 	@textidote --version
 	# allowed to fail since it throws error if we have grammar mistakes
-	-textidote --check en --output html paper.tex > index.html
+	-textidote --check en --output html $<  > index.html
 	python3 -m http.server
 
 refcheck: paper

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ grammar: paper.tex
 	-textidote --check en --output html paper.tex > index.html
 	python3 -m http.server
 
-refcheck: paper.log
+refcheck: paper
 	@grep -e 'refcheck.*Unused' paper.log
 
 ${PDF_PAPER}: ${TEX_MAIN_PAPER} ${IMAGES}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ grammar: paper.tex
 	-textidote --check en --output html paper.tex > index.html
 	python3 -m http.server
 
+refcheck: paper.log
+	@grep -e 'refcheck.*Unused' paper.log
+
 ${PDF_PAPER}: ${TEX_MAIN_PAPER} ${IMAGES}
 	latexmk ${TEX_MAIN_PAPER}
 

--- a/paper.tex
+++ b/paper.tex
@@ -377,8 +377,9 @@ items are formatted in ways that are known to work well.
 \paragraph{Referencing Figures} When referencing figures from the text we
 ensure the following:
 \begin{description}
-      \item [All figures are referenced] A paper with un-referenced figures
-	      appears incomplete.
+      \item [All figures are referenced] A paper with un-referenced figures appears incomplete.
+        We can check this using the \texttt{refcheck} package.
+        Issuing \texttt{make refcheck} on the commandline lists all \emph{labeled} elements that are not referenced in the text.
       \item [References to figures are brief and easy to skip]~\\
                 We minimize the number of words needed to refer to a figure. Reducing
                 the number of non-information-carrying words directly increases

--- a/tex/setup.tex
+++ b/tex/setup.tex
@@ -211,3 +211,22 @@
     \tikz[baseline=(char.base)]{\node[circledstyle, fill=#2] (char) {#3\strut};}%
 }
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Add refcheck support
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage[norefs,nocites]{refcheck}
+
+% make refcheck work with autoref
+% based on: https://tex.stackexchange.com/questions/87610/making-refcheck-work-with-cleveref
+\makeatletter
+\newcommand{\refcheckize}[1]{%
+  \expandafter\let\csname @@\string#1\endcsname#1%
+  \expandafter\DeclareRobustCommand\csname relax\string#1\endcsname[1]{%
+    \csname @@\string#1\endcsname{##1}\wrtusdrf{##1}}%
+  \expandafter\let\expandafter#1\csname relax\string#1\endcsname
+}
+\makeatother
+
+%%% add the reference commands we want refcheck to be aware of
+\refcheckize{\autoref}
+


### PR DESCRIPTION
This PR:

- Adds `Makefile` check (by invoking `make refcheck`) for all labelled elements that are not referenced in the text
- Adds explanatory text on this within the template's writing and style guidelines

PS: I know `textidote` offers this but this is available on every compilation by just parsing the log